### PR TITLE
Remove jsr308.imports and add imports manually for normal javac

### DIFF
--- a/nonnull-interned-demo/checkers/src/checkers/nonnull/FlowCondition.java
+++ b/nonnull-interned-demo/checkers/src/checkers/nonnull/FlowCondition.java
@@ -3,6 +3,10 @@ package checkers.nonnull;
 import com.sun.source.tree.*;
 import com.sun.source.util.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Represents a conditional expression that performs a nonnull check.
  * Specifically, it consists of the operand that is being checked, and whether

--- a/nonnull-interned-demo/checkers/src/checkers/nonnull/FlowScope.java
+++ b/nonnull-interned-demo/checkers/src/checkers/nonnull/FlowScope.java
@@ -3,6 +3,10 @@ package checkers.nonnull;
 import javax.annotation.processing.*;
 import javax.lang.model.element.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Represents the range for which a variable is "valid" with respect to some
  * property (for instance, the range for which a variable is nonnull).

--- a/nonnull-interned-demo/checkers/src/checkers/nonnull/FlowVisitor.java
+++ b/nonnull-interned-demo/checkers/src/checkers/nonnull/FlowVisitor.java
@@ -10,6 +10,10 @@ import java.util.*;
 import javax.annotation.processing.*;
 import javax.lang.model.element.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import static checkers.types.InternalUtils.*;
 
 /**

--- a/nonnull-interned-demo/checkers/src/checkers/nonnull/NonnullAnnotatedTypeFactory.java
+++ b/nonnull-interned-demo/checkers/src/checkers/nonnull/NonnullAnnotatedTypeFactory.java
@@ -15,6 +15,11 @@ import com.sun.source.tree.*;
 import com.sun.source.util.*;
 import com.sun.tools.javac.tree.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.initialization.qual.Initialized;
+
 /**
  * Adds support for the {@code @NonNull} type annotation to
  * {@link AnnotatedTypeFactory}. This means that the

--- a/nonnull-interned-demo/checkers/src/checkers/types/AnnotatedClassType.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/AnnotatedClassType.java
@@ -11,6 +11,10 @@ import checkers.util.ElementUtils;
 
 import com.sun.source.tree.Tree;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * {@link AnnotatedClassType} represents a type along with all its annotations.
  * Given a use of a type, clients can obtain an {@link AnnotatedClassType} and

--- a/nonnull-interned-demo/checkers/src/checkers/types/AnnotatedMethodType.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/AnnotatedMethodType.java
@@ -5,6 +5,10 @@ import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Provides a way to obtain annotated class types for the parts of a
  * method declaration (return type, throws clauses, method receiver,

--- a/nonnull-interned-demo/checkers/src/checkers/types/AnnotatedTypeFactory.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/AnnotatedTypeFactory.java
@@ -17,6 +17,11 @@ import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.comp.*;
 import com.sun.tools.javac.tree.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * A factory for generating annotated types. It is capable of
  * creating annotated class and method types from Tree API nodes. It is designed

--- a/nonnull-interned-demo/checkers/src/checkers/types/AnnotationData.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/AnnotationData.java
@@ -7,6 +7,9 @@ import java.util.*;
 import javax.lang.model.element.*;
 import javax.lang.model.type.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * A general representation for annotations used as type qualifiers.
  * Annotations in this representation will most typically come from annotations

--- a/nonnull-interned-demo/checkers/src/checkers/types/AnnotationFactory.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/AnnotationFactory.java
@@ -11,6 +11,10 @@ import javax.lang.model.element.*;
 import javax.lang.model.type.*;
 import javax.lang.model.util.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Creates new annotations or converts existing annotations in the internal
  * annotation representation ({@link AnnotationData}) used by this framework.

--- a/nonnull-interned-demo/checkers/src/checkers/types/AnnotationLocation.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/AnnotationLocation.java
@@ -13,6 +13,10 @@ import javax.lang.model.type.*;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.Tree;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Represents the location of an annotation within a type.  For example, consider
  *

--- a/nonnull-interned-demo/checkers/src/checkers/types/InternalAnnotation.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/InternalAnnotation.java
@@ -16,6 +16,10 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.comp.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Represents an annotation along with its annotation target (its
  * {@link AnnotationTarget}), which cannot (publicly) be obtained from an

--- a/nonnull-interned-demo/checkers/src/checkers/types/InternalAnnotationGroup.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/InternalAnnotationGroup.java
@@ -8,6 +8,9 @@ import javax.lang.model.element.Element;
 
 import com.sun.source.util.TreeScanner;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * Represents a group of annotations and their associated element. Useful for
  * {@link TreeScanner}s.

--- a/nonnull-interned-demo/checkers/src/checkers/types/InternalAnnotationScanner.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/InternalAnnotationScanner.java
@@ -14,6 +14,8 @@ import com.sun.source.util.*;
 
 import com.sun.tools.javac.comp.AnnotationTarget;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * A scanner for obtaining groups of annotations from a source tree.
  */

--- a/nonnull-interned-demo/checkers/src/checkers/types/InternalUtils.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/InternalUtils.java
@@ -10,6 +10,10 @@ import com.sun.tools.javac.code.*;
 import com.sun.tools.javac.tree.*;
 import com.sun.tools.javac.tree.JCTree.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Static utility methods used by annotation abstractions in this package. Some
  * methods in this class depend on the use of Sun javac internals; any procedure

--- a/nonnull-interned-demo/checkers/src/checkers/types/SyntheticAnnotation.java
+++ b/nonnull-interned-demo/checkers/src/checkers/types/SyntheticAnnotation.java
@@ -10,6 +10,9 @@ import javax.lang.model.element.*;
 import javax.lang.model.type.*;
 import javax.lang.model.util.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * Represents an annotation that was not written as part of a source or class
  * file, but rather was generated. This is primarily useful for annotations

--- a/nonnull-interned-demo/checkers/src/checkers/util/AnnotationUtils.java
+++ b/nonnull-interned-demo/checkers/src/checkers/util/AnnotationUtils.java
@@ -15,6 +15,11 @@ import javax.lang.model.type.*;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.framework.qual.TypeUseLocation;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * A utility class for working with annotations.
  */

--- a/nonnull-interned-demo/checkers/src/checkers/util/ElementUtils.java
+++ b/nonnull-interned-demo/checkers/src/checkers/util/ElementUtils.java
@@ -11,6 +11,10 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * A Utility class for analyzing {@code Element}s
  * 

--- a/nonnull-interned-demo/checkers/src/checkers/util/GenericsUtils.java
+++ b/nonnull-interned-demo/checkers/src/checkers/util/GenericsUtils.java
@@ -15,6 +15,10 @@ import javax.lang.model.type.*;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Utilities for working with annotated generic types, and particularly,
  * applying annotations from annotated type arguments to type variables.

--- a/nonnull-interned-demo/checkers/src/checkers/util/TreeUtils.java
+++ b/nonnull-interned-demo/checkers/src/checkers/util/TreeUtils.java
@@ -11,6 +11,10 @@ import checkers.types.AnnotatedMethodType;
 import com.sun.source.tree.*;
 import com.sun.source.util.TreePath;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * A utility class made for helping to analyze a given {@code Tree}.
  */

--- a/nonnull-interned-demo/checkers/src/checkers/util/TypesUtils.java
+++ b/nonnull-interned-demo/checkers/src/checkers/util/TypesUtils.java
@@ -16,6 +16,9 @@ import javax.lang.model.type.*;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import checkers.types.AnnotationData;
 import checkers.types.AnnotationLocation;

--- a/nonnull-interned-demo/daikon/src/daikon/Daikon.java
+++ b/nonnull-interned-demo/daikon/src/daikon/Daikon.java
@@ -30,6 +30,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 import utilMDE.Assert;
 import utilMDE.FileIOException;
 import utilMDE.Fmt;

--- a/nonnull-interned-demo/daikon/src/daikon/DynamicConstants.java
+++ b/nonnull-interned-demo/daikon/src/daikon/DynamicConstants.java
@@ -18,7 +18,7 @@ import java.util.*;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
-
+import org.checkerframework.checker.interning.qual.Interned;
 
 import utilMDE.*;
 

--- a/nonnull-interned-demo/daikon/src/daikon/FileIO.java
+++ b/nonnull-interned-demo/daikon/src/daikon/FileIO.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 import java.net.*;
 import java.util.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 public final class FileIO {
 
   /** Nobody should ever instantiate a FileIO. **/

--- a/nonnull-interned-demo/daikon/src/daikon/PptName.java
+++ b/nonnull-interned-demo/daikon/src/daikon/PptName.java
@@ -5,6 +5,8 @@ import java.io.Serializable;
 import java.io.IOException;
 import utilMDE.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 /**
  * PptName is an immutable ADT that represents naming data associated with a
  * given program point, such as the class or method.

--- a/nonnull-interned-demo/daikon/src/daikon/ProglangType.java
+++ b/nonnull-interned-demo/daikon/src/daikon/ProglangType.java
@@ -3,6 +3,8 @@ package daikon;
 import java.util.*;
 import java.io.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 import utilMDE.*;
 
 /**

--- a/nonnull-interned-demo/daikon/src/daikon/ValueTuple.java
+++ b/nonnull-interned-demo/daikon/src/daikon/ValueTuple.java
@@ -6,6 +6,8 @@ import java.util.logging.Logger;
 
 import java.util.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 import utilMDE.*;
 
 /**

--- a/nonnull-interned-demo/daikon/src/daikon/VarInfo.java
+++ b/nonnull-interned-demo/daikon/src/daikon/VarInfo.java
@@ -22,6 +22,8 @@ import java.util.logging.Level;
 import java.util.*;
 import java.io.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 /**
  * Represents information about a particular variable for a program
  * point.  This object doesn't hold the value of the variable at a

--- a/nonnull-interned-demo/daikon/src/daikon/VarInfoAux.java
+++ b/nonnull-interned-demo/daikon/src/daikon/VarInfoAux.java
@@ -5,6 +5,8 @@ import java.util.*;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 /**
  * Represents additional information about a VarInfo that frontends
  * tell Daikon.  For example, whether order matters in a collection.

--- a/nonnull-interned-demo/daikon/src/daikon/VarInfoName.java
+++ b/nonnull-interned-demo/daikon/src/daikon/VarInfoName.java
@@ -19,6 +19,8 @@ import java.io.ObjectInputStream;
 import java.io.IOException;
 import java.util.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 // This class is deprecated.  It should be removed as soon as Daikon no
 // longer supports the old decl format.
 

--- a/nonnull-interned-demo/daikon/src/daikon/chicory/DTraceReader.java
+++ b/nonnull-interned-demo/daikon/src/daikon/chicory/DTraceReader.java
@@ -5,6 +5,8 @@ import utilMDE.*;
 import java.util.*;
 import java.io.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 /**
  * Reads dtrace files and provides methods to access the information
  * within them.  A dtrace file contains both declarations and data.

--- a/nonnull-interned-demo/daikon/src/daikon/chicory/DeclReader.java
+++ b/nonnull-interned-demo/daikon/src/daikon/chicory/DeclReader.java
@@ -5,6 +5,8 @@ import utilMDE.*;
 import java.util.*;
 import java.io.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 /**
  * Reads declaration files and provides methods to access the information
  * within them.  A declaration file consists of a number of program points

--- a/nonnull-interned-demo/daikon/src/daikon/inv/InvariantStatus.java
+++ b/nonnull-interned-demo/daikon/src/daikon/inv/InvariantStatus.java
@@ -1,6 +1,6 @@
 package daikon.inv;
 
-
+import org.checkerframework.checker.interning.qual.Interned;
 
 /**
  * This class is an enumerated type representing the possible results of

--- a/nonnull-interned-demo/daikon/src/utilMDE/Intern.java
+++ b/nonnull-interned-demo/daikon/src/utilMDE/Intern.java
@@ -3,6 +3,8 @@ package utilMDE;
 import java.lang.ref.WeakReference;
 import java.util.*;
 
+import org.checkerframework.checker.interning.qual.Interned;
+
 /**
  * Utilities for interning objects.
  **/

--- a/nonnull-interned-demo/lib/ant.xml
+++ b/nonnull-interned-demo/lib/ant.xml
@@ -28,7 +28,6 @@
         <arg line="-classpath ${deps.lib}:${checker.lib}:${daikon.lib}:@{custom.lib}"/>
         <arg line="-J-Xmx3G"/>
         <arg line="-J-Xss5M"/>
-        <arg line="-J-Djsr308.imports='org.checkerframework.framework.qual.*:org.checkerframework.checker.nullness.qual.*:org.checkerframework.checker.initialization.qual.*:org.checkerframework.checker.interning.qual.*'"/>
         <arg line="-sourcepath @{srcpath}"/>
         <arg line="-processor @{checker}"/>
         <arg line="-implicit:none"/>

--- a/nonnull-interned-demo/lookup/src/java/io/ByteArrayOutputStream.java
+++ b/nonnull-interned-demo/lookup/src/java/io/ByteArrayOutputStream.java
@@ -1,5 +1,7 @@
 package java.io;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 public class ByteArrayOutputStream extends OutputStream {
   public ByteArrayOutputStream() { throw new RuntimeException("skeleton method"); }
   public ByteArrayOutputStream(int a1) { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/io/File.java
+++ b/nonnull-interned-demo/lookup/src/java/io/File.java
@@ -1,5 +1,9 @@
 package java.io;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 @DefaultQualifier(NonNull.class)
 public class File implements java.io.Serializable, java.lang.Comparable<java.io.File> {
   private static final long serialVersionUID = 0;

--- a/nonnull-interned-demo/lookup/src/java/io/ObjectInputStream.java
+++ b/nonnull-interned-demo/lookup/src/java/io/ObjectInputStream.java
@@ -1,5 +1,7 @@
 package java.io;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 public class ObjectInputStream extends InputStream implements ObjectInput, ObjectStreamConstants {
   public static abstract class GetField{
     public GetField() { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/io/StringWriter.java
+++ b/nonnull-interned-demo/lookup/src/java/io/StringWriter.java
@@ -1,5 +1,8 @@
 package java.io;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public class StringWriter extends Writer {
   public StringWriter() { throw new RuntimeException("skeleton method"); }
   public StringWriter(int a1) { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/lang/Class.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/Class.java
@@ -3,6 +3,9 @@ package java.lang;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public final class Class<T> implements java.io.Serializable, java.lang.reflect.GenericDeclaration, java.lang.reflect.Type, java.lang.reflect.AnnotatedElement {
   public @NonNull String toString() { throw new RuntimeException("skeleton method"); }
   public static @NonNull Class<?> forName(@NonNull String a1) throws ClassNotFoundException { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/lang/ClassLoader.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/ClassLoader.java
@@ -1,5 +1,7 @@
 package java.lang;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 public abstract class ClassLoader{
   public Class<?> loadClass(String a1) throws ClassNotFoundException { throw new RuntimeException("skeleton method"); }
   public java.net.URL getResource(String a1) { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/lang/Double.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/Double.java
@@ -1,5 +1,7 @@
 package java.lang;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 public final class Double extends java.lang.Number implements java.lang.Comparable<java.lang.Double> {
   public final static double POSITIVE_INFINITY = 1.0 / 0.0;
   public final static double NEGATIVE_INFINITY = -1.0 / 0.0;

--- a/nonnull-interned-demo/lookup/src/java/lang/Integer.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/Integer.java
@@ -1,5 +1,8 @@
 package java.lang;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public final class Integer extends java.lang.Number implements java.lang.Comparable<java.lang.Integer> {
   public final static int MIN_VALUE = -2147483648;
   public final static int MAX_VALUE = 2147483647;

--- a/nonnull-interned-demo/lookup/src/java/lang/Object.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/Object.java
@@ -1,5 +1,8 @@
 package java.lang;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public class Object{
   public Object() { throw new RuntimeException("skeleton method"); }
   public boolean equals(@Nullable Object a1) { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/lang/String.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/String.java
@@ -1,5 +1,9 @@
 package java.lang;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 @DefaultQualifier(NonNull.class)
 public final class String implements java.io.Serializable, java.lang.Comparable<java.lang.String>, java.lang.CharSequence {
   private static final long serialVersionUID = 0;

--- a/nonnull-interned-demo/lookup/src/java/lang/StringBuffer.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/StringBuffer.java
@@ -1,5 +1,8 @@
 package java.lang;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public final class StringBuffer{
   public StringBuffer() { throw new RuntimeException("skeleton method"); }
   public StringBuffer(int a1) { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/lang/StringBuilder.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/StringBuilder.java
@@ -1,5 +1,7 @@
 package java.lang;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 public final class StringBuilder{
   public StringBuilder() { throw new RuntimeException("skeleton method"); }
   public StringBuilder(int a1) { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/lang/reflect/Field.java
+++ b/nonnull-interned-demo/lookup/src/java/lang/reflect/Field.java
@@ -2,7 +2,7 @@ package java.lang.reflect;
 
 import java.lang.annotation.Annotation;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class Field{
   public @NonNull Class<?> getDeclaringClass() { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/util/ArrayList.java
+++ b/nonnull-interned-demo/lookup/src/java/util/ArrayList.java
@@ -1,6 +1,6 @@
 package java.util;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class ArrayList<E> extends java.util.AbstractList<E> implements java.util.List<E>, java.util.RandomAccess, java.lang.Cloneable, java.io.Serializable {
   public ArrayList(int a1) { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/util/BitSet.java
+++ b/nonnull-interned-demo/lookup/src/java/util/BitSet.java
@@ -1,6 +1,6 @@
 package java.util;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class BitSet implements Cloneable, java.io.Serializable {
   public BitSet() { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/util/Collection.java
+++ b/nonnull-interned-demo/lookup/src/java/util/Collection.java
@@ -1,6 +1,6 @@
 package java.util;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public abstract interface Collection<E> extends java.lang.Iterable<E> {
   public abstract int size();

--- a/nonnull-interned-demo/lookup/src/java/util/Iterator.java
+++ b/nonnull-interned-demo/lookup/src/java/util/Iterator.java
@@ -1,6 +1,6 @@
 package java.util;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public abstract interface Iterator<E> {
   public abstract boolean hasNext();

--- a/nonnull-interned-demo/lookup/src/java/util/List.java
+++ b/nonnull-interned-demo/lookup/src/java/util/List.java
@@ -1,6 +1,6 @@
 package java.util;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public abstract interface List<E> extends java.util.Collection<E> {
   public abstract int size();

--- a/nonnull-interned-demo/lookup/src/java/util/Map.java
+++ b/nonnull-interned-demo/lookup/src/java/util/Map.java
@@ -1,6 +1,6 @@
 package java.util;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public abstract interface Map<K, V> {
   public abstract interface Entry<K, V> {

--- a/nonnull-interned-demo/lookup/src/java/util/Properties.java
+++ b/nonnull-interned-demo/lookup/src/java/util/Properties.java
@@ -7,7 +7,8 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class Properties extends java.util.Hashtable<java.lang.Object, java.lang.Object> {
   public Properties() { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/java/util/Set.java
+++ b/nonnull-interned-demo/lookup/src/java/util/Set.java
@@ -1,6 +1,6 @@
 package java.util;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public abstract interface Set<E> extends java.util.Collection<E> {
   public abstract int size();

--- a/nonnull-interned-demo/lookup/src/java/util/StringTokenizer.java
+++ b/nonnull-interned-demo/lookup/src/java/util/StringTokenizer.java
@@ -1,6 +1,6 @@
 package java.util;
 
-
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class StringTokenizer implements java.util.Enumeration<@NonNull Object> {
   public StringTokenizer(@NonNull String a1, @NonNull String a2, boolean a3) { throw new RuntimeException("skeleton method"); }

--- a/nonnull-interned-demo/lookup/src/utilMDE/Filter.java
+++ b/nonnull-interned-demo/lookup/src/utilMDE/Filter.java
@@ -1,6 +1,7 @@
 package utilMDE;
 
-
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Interface for things that make boolean decisions.

--- a/nonnull-interned-demo/lookup/src/utilMDE/RandomSelector.java
+++ b/nonnull-interned-demo/lookup/src/utilMDE/RandomSelector.java
@@ -4,6 +4,8 @@ package utilMDE;
 
 import java.util.*;
 
+import org.checkerframework.framework.qual.DefaultQualifier;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  *

--- a/nonnull-interned-demo/lookup/src/utilMDE/UtilMDE.java
+++ b/nonnull-interned-demo/lookup/src/utilMDE/UtilMDE.java
@@ -10,6 +10,10 @@ import java.util.zip.*;
 import java.lang.reflect.*;
 // import Assert;
 
+import org.checkerframework.checker.nullness.qual.KeyFor;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 // The class name "UtilMDE" is very close to the package name "utilMDE".
 /** Utility functions that do not belong elsewhere in the utilMDE package. */
 public final class UtilMDE {


### PR DESCRIPTION
Presently the demo cannot be ran with a normal javac because an option `jsr308.imports` is used to implicitly import packages that are needed for annotation packages. This PR removes the use of the option and adds those import statements to all the source files so that a normal javac can be used.