### PR TITLE
Build with docker as the other repos

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -7,7 +7,7 @@ set -e
 
 export SHELLOPTS
 
-ROOT=$TRAVIS_BUILD_DIR/..
+ROOT=`readlink -f ..`
 
 export CHECKERFRAMEWORK=`readlink -f ${CHECKERFRAMEWORK:-$ROOT/checker-framework}`
 
@@ -30,7 +30,7 @@ else
     REPO=`/tmp/plume-scripts/git-find-fork ${SLUGOWNER} typetools checker-framework`
     BRANCH=`/tmp/plume-scripts/git-find-branch ${REPO} ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}`
     echo "About to execute: (git clone -b $BRANCH --single-branch --depth 1 $REPO)"
-    git clone -b ${BRANCH} --single-branch --depth 1 ${REPO}{CHECKERFRAMEWORK} || git clone -b ${BRANCH} --single-branch --depth 1 ${REPO} ${CHECKERFRAMEWORK}
+    git clone -b ${BRANCH} --single-branch --depth 1 ${REPO} ${CHECKERFRAMEWORK} || git clone -b ${BRANCH} --single-branch --depth 1 ${REPO} ${CHECKERFRAMEWORK}
 fi
 
 # This also builds annotation-tools and jsr308-langtools

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Entering checker-framework-demos/.travis-build.sh"
+echo "Entering `pwd`/.travis-build.sh"
 
 # Fail the whole script if any command fails
 set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,4 @@
-language: java
-
-script: ./.travis-build.sh
-
-## Reinstate when the build can use a standard jtreg install
-# addons:
-#   apt:
-#     packages:
-#       - jtreg
+language: generic
 
 # Enable Gradle caching
 before_cache:
@@ -18,8 +10,65 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.m2/
 
-jdk:
-  - oraclejdk8
+services:
+  - docker
+
+env:
+  global:
+    - THIS_REPO=checker-framework.demos
+    - OS=ubuntu
+    - JDKVER=jdk8
+
+# The "docker run" command will pull if needed.
+# Running this first gives two tries in case of network lossage.
+before_script:
+  - timeout 5m docker pull mdernst/$OS-for-cf-$JDKVER || true
+
+
+# Using travis_wait here seems to cause the job to terminate after 1 minute
+# with no error (!).
+# The git commands are tried twice, in case of temporary network failure.
+# The fcntl line works around a bug where Travis truncates logs and fails.
+script:
+- python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
+- REMOTE_ORIGIN_URL=`git config --get remote.origin.url`
+- echo "THIS_REPO=${THIS_REPO}"
+- echo "JDKVER=${JDKVER}"
+- echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}"
+- echo "REMOTE_ORIGIN_URL=${REMOTE_ORIGIN_URL}"
+- echo "TRAVIS_EVENT_TYPE=${TRAVIS_EVENT_TYPE}"
+- echo "TRAVIS_COMMIT_RANGE=${TRAVIS_COMMIT_RANGE}"
+- echo "TRAVIS_COMMIT=${TRAVIS_COMMIT}"
+- echo "TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}"
+- echo "TRAVIS_PULL_REQUEST_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH}"
+- echo "TRAVIS_PULL_REQUEST_SHA=${TRAVIS_PULL_REQUEST_SHA}"
+- echo "TRAVIS_PULL_REQUEST_SLUG=${TRAVIS_PULL_REQUEST_SLUG}"
+- echo "TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}"
+- >-
+  docker run -v $HOME/.gradle:/root/.gradle -v $HOME/.m2:/root/.m2 mdernst/$OS-for-cf-$JDKVER /bin/bash -c "true &&
+     if [ $TRAVIS_EVENT_TYPE = pull_request ] ; then
+       git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet $REMOTE_ORIGIN_URL $THIS_REPO
+       cd $THIS_REPO
+       git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge
+       git checkout -qf $TRAVIS_PULL_REQUEST_SHA
+       git config user.email noone@cares.com
+       git config user.name Noone Cares
+       git remote add theupstream https://github.com/$TRAVIS_REPO_SLUG.git
+       git pull theupstream $TRAVIS_BRANCH || git pull theupstream $TRAVIS_BRANCH
+     else
+       git clone --quiet -b $TRAVIS_BRANCH $REMOTE_ORIGIN_URL $THIS_REPO || git clone --quiet -b $TRAVIS_BRANCH $REMOTE_ORIGIN_URL $THIS_REPO
+       cd $THIS_REPO
+       git checkout -qf $TRAVIS_COMMIT
+     fi &&
+     export JAVA_HOME=\`which javac|xargs readlink -f|xargs dirname|xargs dirname\` &&
+     java -version &&
+     javac -version &&
+     export TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG &&
+     export TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE &&
+     export TRAVIS_PULL_REQUEST_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH} &&
+     export TRAVIS_PULL_REQUEST_SLUG=${TRAVIS_PULL_REQUEST_SLUG} &&
+     export TRAVIS_BRANCH=${TRAVIS_BRANCH} &&
+     ./.travis-build.sh"
 
 git:
-  depth: 3
+  depth: 9

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ script:
      java -version &&
      javac -version &&
      export TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG &&
+     export TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR &&
      export TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE &&
      export TRAVIS_PULL_REQUEST_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH} &&
      export TRAVIS_PULL_REQUEST_SLUG=${TRAVIS_PULL_REQUEST_SLUG} &&


### PR DESCRIPTION
This is bascially a counterpart of https://github.com/eisop/checker-framework.demos/pull/2.

This PR unifies the environment used to build this project as other related projects on Travis so as to avoid certain issues related to Travis (e.g. low version Python/TLS, missing oraclejdk8).